### PR TITLE
Fixed migration of deleted usernames so the don't appear as 'Guest'

### DIFF
--- a/boards/phpbb3/posts.php
+++ b/boards/phpbb3/posts.php
@@ -47,7 +47,7 @@ class PHPBB3_Converter_Module_Posts extends Converter_Module_Posts {
 		$insert_data['subject'] = encode_to_utf8($this->bbcode_parser->convert_title($data['post_subject']), "posts", "posts");
 		$insert_data['uid'] = $this->get_import->uid($data['poster_id']);
 		$insert_data['import_uid'] = $data['poster_id'];
-		$insert_data['username'] = $this->get_import->username($data['poster_id']);
+		$insert_data['username'] = $this->get_import->username($data['poster_id'], $data['post_username']);
 		$insert_data['dateline'] = $data['post_time'];
 		$insert_data['message'] = encode_to_utf8($this->bbcode_parser->convert($data['post_text'], $data['bbcode_uid']), "posts", "posts");
 		$insert_data['ipaddress'] = $data['poster_ip'];

--- a/resources/class_cache_handler.php
+++ b/resources/class_cache_handler.php
@@ -271,7 +271,7 @@ class Cache_Handler
 	 * @param string Username used before import
 	 * @return string Username in MyBB or the old username (if provided)/'Guest' if the old UID cannot be found
 	 */
-	function username($old_uid, $old_username="")
+	function username($old_uid, $old_username)
 	{
 		if(!is_array($this->cache_usernames))
 		{


### PR DESCRIPTION
Unregistred/Deleted user in phpBB3 named "Bob" appears as "Guest" after migration.

This fixed the issue so "Bob" appears as "Bob".
