### PR TITLE
Fixes #47 Forumpermissions module not working

### DIFF
--- a/boards/bbpress.php
+++ b/boards/bbpress.php
@@ -64,6 +64,20 @@ class BBPRESS_Converter extends Converter
 	var $prefix_suggestion = "wp_";
 	
 	/**
+	 * An array of bbpress -> mybb groups
+	 * bbpress doesn't use id's but names
+	 *
+	 * @var array
+	 */
+	var $groups = array(
+		"blocked" => MYBB_BANNED, // Banned
+		"member" => MYBB_REGISTERED, // Registered
+		"moderator" => MYBB_SMODS, // Super Moderators
+		"keymaster" => MYBB_ADMINS, // Administrators
+		"administrator" => MYBB_REGISTERED, // Administrators
+	);
+
+	/**
 	 * Convert a bbPress group ID into a MyBB group ID
 	 *
 	 * @param int Group ID
@@ -82,49 +96,21 @@ class BBPRESS_Converter extends Converter
 		}
 
 		$query = $this->old_db->simple_select("usermeta", "*", "user_id = '{$uid}' AND meta_key = '".$this->old_db->table_prefix."capabilities'", $settings);
+		if(!$query)
+		{
+			return MYBB_REGISTERED;
+		}
 
-		$comma = $group = '';
+		$groups = array();
 		while($bbpress = $this->old_db->fetch_array($query))
 		{
 			$bbpress['group_id'] = preg_replace('#\w+:\d+:{\w+:\d+:\"(.*?)\";\w+:\d+;}#', '$1', $bbpress['meta_value']);
-			$group .= $comma;
-			switch($bbpress['group_id'])
-			{
-				case "member": // Register
-					$group .= 1;
-					break;
-				case "moderator": // Super Moderator
-					$group .= 3;
-					break;
-				case "keymaster": // Administrator
-				case "administrator":
-					$group .= 4;
-					break;
-				case "blocked": // Banned...
-					$group .= 7;
-					break;
-				default:
-					$gid = $this->get_import->gid($bbpress['group_id']);
-					if($gid > 0)
-					{
-						// If there is an associated custom group...
-						$group .= $gid;
-					}
-					else
-					{
-						// The lot
-						$group .= 2;
-					}
-			}
-			$comma = ',';
-		}
-		if(!$query)
-		{
-			return 2; // Return regular registered user.
+
+			$groups[] = $this->get_gid($bbpress['group_id']);
 		}
 
 		$this->old_db->free_result($query);
-		return $group;
+		return implode(',', array_unique($groups));
 	}
 }
 

--- a/boards/ipb3.php
+++ b/boards/ipb3.php
@@ -78,6 +78,20 @@ class IPB3_Converter extends Converter {
 		);
 
 	/**
+	 * An array of ipb3 -> mybb groups
+	 *
+	 * @var array
+	 */
+	var $groups = array(
+		1 => MYBB_AWAITING, // Awaiting Activation
+		2 => MYBB_GUESTS, // Guests
+		3 => MYBB_REGISTERED, // Registered
+		4 => MYBB_ADMINS, // Root Admin
+		5 => MYBB_BANNED, // Banned
+		6 => MYBB_ADMINS, // Administrators
+	);
+
+	/**
 	 * Convert a IPB group ID into a MyBB group ID
 	 *
 	 * @param int Group ID
@@ -96,60 +110,26 @@ class IPB3_Converter extends Converter {
 			$query = $this->old_db->simple_select("groups", "*", "g_id='{$gid}'");
 		}
 
-		$comma = $group = '';
+		if(!$query)
+		{
+			return MYBB_REGISTERED;
+		}
+
+		$groups = array();
 		while($ipbgroup = $this->old_db->fetch_array($query))
 		{
 			if($options['original'] == true)
 			{
-				$group .= $ipbgroup['g_id'].$comma;
+				$groups[] = $ipbgroup['g_id'];
 			}
 			else
 			{
-				$group .= $comma;
-				switch($ipbgroup['g_id'])
-				{
-					case 1: // Awaiting activation
-						$group .= 5;
-						break;
-					case 2: // Guests
-						$group .= 1;
-						break;
-					case 3: // Registered
-						$group .= 2;
-						break;
-					case 5: // Banned
-						$group .= 7;
-						break;
-					case 4: // Root Admin
-						$group .= 4;
-						break;
-					case 6: // Administrator
-						$group .= 6;
-						break;
-					default:
-						$gid = $this->get_import->gid($ipbgroup['g_id']);
-						if($gid > 0)
-						{
-							// If there is an associated custom group...
-							$group .= $gid;
-						}
-						else
-						{
-							// The lot
-							$group .= 2;
-						}
-				}
+				$groups[] = $this->get_gid($ipbgroup['g_id']);
 			}
-			$comma = ',';
-		}
-
-		if(!$query)
-		{
-			return 2; // Return regular registered user.
 		}
 
 		$this->old_db->free_result($query);
-		return $group;
+		return implode(',', array_unique($groups));
 	}
 }
 

--- a/boards/ipb3/forumperms.php
+++ b/boards/ipb3/forumperms.php
@@ -77,7 +77,7 @@ class IPB3_Converter_Module_Forumperms extends Converter_Module_Forumperms {
 				$query = $this->old_db->simple_select("groups", "g_id");
 				while($group = $this->old_db->fetch_array($query))
 				{
-					$new_perms[$this->board->get_group_id($group['g_id'], array("not_multiple" => true))][$key] = 1;
+					$new_perms[$this->board->get_gid($group['g_id'])][$key] = 1;
 				}
 			}
 			else
@@ -85,7 +85,7 @@ class IPB3_Converter_Module_Forumperms extends Converter_Module_Forumperms {
 				$perm_split = explode(',', $permission);
 				foreach($perm_split as $key2 => $gid)
 				{
-					$new_perms[$this->board->get_group_id($gid, array("not_multiple" => true))][$key] = 1;
+					$new_perms[$this->board->get_gid($gid, array("not_multiple" => true))][$key] = 1;
 				}
 			}
 		}

--- a/boards/phpbb3.php
+++ b/boards/phpbb3.php
@@ -72,6 +72,21 @@ class PHPBB3_Converter extends Converter
 	var $prefix_suggestion = "phpbb_";
 	
 	/**
+	 * An array of phpbb -> mybb groups
+	 * 
+	 * @var array
+	 */
+	var $groups = array(
+		1 => MYBB_GUESTS, // Guests
+		2 => MYBB_REGISTERED, // Registered
+		3 => MYBB_REGISTERED, // Newly registered
+		4 => MYBB_SMODS, // Super Moderators
+		5 => MYBB_ADMINS, // Administrators
+		6 => MYBB_GUESTS, // Bots
+		7 => MYBB_REGISTERED, // Newly registered
+	);
+
+	/**
 	 * Convert a phpBB 3 group ID into a MyBB group ID
 	 *
 	 * @param int Group ID
@@ -89,61 +104,32 @@ class PHPBB3_Converter extends Converter
 		}
 
 		$query = $this->old_db->simple_select("user_group", "*", "user_id = '{$uid}'", $settings);
+		if(!$query)
+		{
+			return MYBB_REGISTERED;
+		}
 
-		$group = array();
+		$groups = array();
 		while($phpbbgroup = $this->old_db->fetch_array($query))
 		{
 			if($options['original'] == true)
 			{
-				$group[$phpbbgroup['group_id']] = 1;
+				$groups[] = $phpbbgroup['group_id'];
 			}
 			else
 			{
 				// Deal with non-activated people
 				if($phpbbgroup['user_pending'] != '0')
 				{
-					return 5;
+					return MYBB_AWAITING;
 				}
 
-				switch($phpbbgroup['group_id'])
-				{
-					case 1: // Guests
-					case 6: // Bots
-						$group[1] = 1;
-						break;
-					case 2: // Register
-					case 3: // Registered coppa
-					case 7: // Newly Registered
-						$group[2] = 1;
-						break;
-					case 4: // Super Moderator
-						$group[3] = 1;
-						break;
-					case 5: // Administrator
-						$group[4] = 1;
-						break;
-					default:
-						$gid = $this->get_import->gid($phpbbgroup['group_id']);
-						if($gid > 0)
-						{
-							// If there is an associated custom group...
-							$group[$gid] = 1;
-						}
-						else
-						{
-							// The lot
-							$group[2] = 1;
-						}
-				}
+				$groups[] = $this->get_gid($phpbbgroup['group_id']);
 			}
-		}
-		if(!$query)
-		{
-			return 2; // Return regular registered user.
 		}
 
 		$this->old_db->free_result($query);
-		return implode(',', array_keys($group));
+		return implode(',', array_unique($groups));
 	}
 }
 

--- a/boards/punbb.php
+++ b/boards/punbb.php
@@ -66,7 +66,19 @@ class PUNBB_Converter extends Converter
 	 * @var String
 	 */
 	var $prefix_suggestion = "punbb_";
-	
+
+	/**
+	 * An array of punbb -> mybb groups
+	 *
+	 * @var array
+	 */
+	var $groups = array(
+		1 => MYBB_ADMINS, // Administrators
+		2 => MYBB_MODS, // Moderators
+		3 => MYBB_GUESTS, // Guests
+		4 => MYBB_REGISTERED, // Registered
+	);
+
 	/**
 	 * Get a user from the punBB database
 	 *
@@ -100,53 +112,13 @@ class PUNBB_Converter extends Converter
 	 */
 	function get_group_id($gid, $options=array())
 	{
-		static $groupcache;
-		if(!isset($groupcache))
+		if($options['original'] == true)
 		{
-			$groupcache = array();
-			$query = $this->old_db->simple_select("groups", "g_id");
-			while($punbbgroup = $this->old_db->fetch_array($query))
-			{
-				switch($punbbgroup['g_id'])
-				{
-					case 1: // Administrator
-						$group = 4;
-						break;
-					case 2: // Moderator
-						$group = 6;
-						break;
-					case 3: // Guest
-						$group = 1;
-						break;
-					case 4: // Member
-						$group = 2;
-						break;
-					default:
-						$group = $this->get_import->gid($punbbgroup['g_id']);
-						if($group <= 0)
-						{
-							// The lot
-							$group = 2;
-						}
-				}
-				$groupcache[$punbbgroup['g_id']] = $group;
-			}
-		}
-
-		if(isset($groupcache[$gid]))
-		{
-			if($options['original'] == true)
-			{
-				return $gid;
-			}
-			else
-			{
-				return $groupcache[$gid];
-			}
+			return $gid;
 		}
 		else
 		{
-			return 2; // Return regular registered user.
+			return $this->get_gid($punbbgroup['g_id']);
 		}
 	}
 }

--- a/boards/punbb/forumperms.php
+++ b/boards/punbb/forumperms.php
@@ -38,7 +38,7 @@ class PUNBB_Converter_Module_Forumperms extends Converter_Module_Forumperms {
 
 		// punBB values
 		$insert_data['fid'] = $this->get_import->fid_f($data['forum_id']);
-		$insert_data['gid'] = $this->board->get_group_id($data['group_id']);
+		$insert_data['gid'] = $this->board->get_gid($data['group_id']);
 		$insert_data['canpostthreads'] = $data['post_topics'];
 		$insert_data['canpostreplys'] = $data['post_replies'];
 		$insert_data['canview'] = $data['read_forum'];

--- a/boards/smf.php
+++ b/boards/smf.php
@@ -73,6 +73,18 @@ class SMF_Converter extends Converter
 	 */
 	var $prefix_suggestion = "smf_";
 
+	/**
+	 * An array of smf -> mybb groups
+	 *
+	 * @var array
+	 */
+	var $groups = array(
+		1 => MYBB_ADMINS, // Administrators
+		2 => MYBB_SMODS, // Super Moderators
+		3 => MYBB_MODS, // Moderators
+		// 0 => MYBB_REGISTERED, // Registered
+	);
+
 	var $get_post_cache = array();
 
 	/**
@@ -110,7 +122,7 @@ class SMF_Converter extends Converter
 	{
 		if(empty($group_id))
 		{
-			return 2; // Return regular registered user.
+			return MYBB_REGISTERED;
 		}
 
 		if(!is_numeric($group_id))
@@ -123,46 +135,19 @@ class SMF_Converter extends Converter
 		}
 
 
-		$comma = $group = '';
+		$ngroups = array();
 		foreach($groups as $key => $smfgroup)
 		{
 			// Deal with non-activated people
 			if($is_activated != 1 && $is_group_row == true)
 			{
-				return 5;
+				return MYBB_AWAITING;
 			}
 
-			$group .= $comma;
-			switch($smfgroup)
-			{
-				case 1: // Administrator
-					$group .= 4;
-					break;
-				case 2: // Super moderator
-					$group .= 3;
-					break;
-				case 3: // Moderator
-					$group .= 6;
-					break;
-				// case 0 group = 2 // Member
-				default:
-					$gid = $this->get_import->gid($smfgroup);
-					if($gid > 0)
-					{
-						// If there is an associated custom group...
-						$group .= $gid;
-					}
-					else
-					{
-						// The lot
-						$group .= 2;
-					}
-
-			}
-			$comma = ',';
+			$ngroups[] = $this->get_gid($punbbgroup['g_id']);
 		}
 
-		return $group;
+		return implode(',', array_unique($ngroups));
 	}
 }
 

--- a/boards/smf/forumperms.php
+++ b/boards/smf/forumperms.php
@@ -56,7 +56,7 @@ class SMF_Converter_Module_Forumperms extends Converter_Module_Forumperms {
 
 		// SMF values
 		$insert_data['fid'] = $this->get_import->fid($data['ID_BOARD']);
-		$insert_data['gid'] = $this->get_import->gid($data['ID_GROUP']);
+		$insert_data['gid'] = $this->board->get_gid($data['ID_GROUP']);
 
 		$permissions = explode(',', $data['permissions']);
 		foreach($permissions as $name)

--- a/boards/smf2.php
+++ b/boards/smf2.php
@@ -75,6 +75,18 @@ class SMF2_Converter extends Converter
 	 */
 	var $prefix_suggestion = "smf_";
 
+	/**
+	 * An array of smf -> mybb groups
+	 *
+	 * @var array
+	 */
+	var $groups = array(
+		1 => MYBB_ADMINS, // Administrators
+		2 => MYBB_SMODS, // Super Moderators
+		3 => MYBB_MODS, // Moderators
+		// 0 => MYBB_REGISTERED, // Registered
+	);
+
 	var $get_post_cache = array();
 
 	/**
@@ -112,7 +124,7 @@ class SMF2_Converter extends Converter
 	{
 		if(empty($group_id))
 		{
-			return 2; // Return regular registered user.
+			return MYBB_REGISTERED;
 		}
 
 		if(!is_numeric($group_id))
@@ -125,46 +137,19 @@ class SMF2_Converter extends Converter
 		}
 
 
-		$comma = $group = '';
+		$ngroups = array();
 		foreach($groups as $key => $smfgroup)
 		{
 			// Deal with non-activated people
 			if($is_activated != 1 && $is_group_row == true)
 			{
-				return 5;
+				return MYBB_AWAITING;
 			}
 
-			$group .= $comma;
-			switch($smfgroup)
-			{
-				case 1: // Administrator
-					$group .= 4;
-					break;
-				case 2: // Super moderator
-					$group .= 3;
-					break;
-				case 3: // Moderator
-					$group .= 6;
-					break;
-				// case 0 group = 2 // Member
-				default:
-					$gid = $this->get_import->gid($smfgroup);
-					if($gid > 0)
-					{
-						// If there is an associated custom group...
-						$group .= $gid;
-					}
-					else
-					{
-						// The lot
-						$group .= 2;
-					}
-
-			}
-			$comma = ',';
+			$ngroups[] = $this->get_gid($punbbgroup['g_id']);
 		}
 
-		return $group;
+		return implode(',', array_unique($ngroups));
 	}
 }
 

--- a/boards/smf2/forumperms.php
+++ b/boards/smf2/forumperms.php
@@ -41,7 +41,7 @@ class SMF2_Converter_Module_Forumperms extends Converter_Module_Forumperms {
 			SELECT p.id_group, GROUP_CONCAT(p.permission) as permissions, b.id_board
 			FROM ".OLD_TABLE_PREFIX."boards b
 			LEFT JOIN ".OLD_TABLE_PREFIX."board_permissions p ON (p.id_profile=b.id_profile)
-			WHERE p.id_group>4 AND p.permission IN ('".implode("','", array_keys($this->perm2mybb))."')
+			WHERE p.permission IN ('".implode("','", array_keys($this->perm2mybb))."')
 			GROUP BY b.id_board
 			LIMIT {$this->trackers['start_forumperms']}, {$import_session['forumperms_per_screen']}
 		");
@@ -57,7 +57,7 @@ class SMF2_Converter_Module_Forumperms extends Converter_Module_Forumperms {
 
 		// SMF values
 		$insert_data['fid'] = $this->get_import->fid($data['id_board']);
-		$insert_data['gid'] = $this->get_import->gid($data['id_group']);
+		$insert_data['gid'] = $this->board->get_gid($data['id_group']);
 
 		$permissions = explode(',', $data['permissions']);
 		foreach($permissions as $name)

--- a/boards/vbulletin4/forumperms.php
+++ b/boards/vbulletin4/forumperms.php
@@ -38,7 +38,7 @@ class VBULLETIN3_Converter_Module_Forumperms extends Converter_Module_Forumperms
 
 		// vBulletin 3 values
 		$insert_data['fid'] = $this->get_import->fid($data['forumid']);
-		$insert_data['gid'] = $this->board->get_group_id($data['usergroupid'], array("not_multiple" => true));
+		$insert_data['gid'] = $this->board->get_gid($data['usergroupid']);
 
 		$perm_bits = array(
 			"canview" => 1,

--- a/index.php
+++ b/index.php
@@ -535,6 +535,16 @@ if($import_session['finished_convert'] == '1')
 	update_import_session();
 }
 
+// MyBB Group constants. Used for better readability
+// We need them here to make 100% sure they're defined when creating our classes
+define("MYBB_GUESTS",		1);
+define("MYBB_REGISTERED",	2);
+define("MYBB_SMODS",		3);
+define("MYBB_ADMINS",		4);
+define("MYBB_AWAITING",		5);
+define("MYBB_MODS",			6);
+define("MYBB_BANNED",		7);
+
 if($mybb->input['board'])
 {
 	$debug->log->event("Setting up board merge classes: {$mybb->input['board']}");

--- a/resources/class_converter.php
+++ b/resources/class_converter.php
@@ -266,6 +266,29 @@ class Converter
 
 		$output->set_error_notice_in_progress($error_message);
 	}
-}
 
+	public function get_gid($gid)
+	{
+		// A default group, return the correct MyBB group
+		if(isset($this->groups) && isset($this->groups[$gid]))
+		{
+			return $this->groups[$gid];
+		}
+		// Custom group
+		else
+		{
+			$gid = $this->get_import->gid($gid);
+			// we found the correct group
+			if($gid > 0)
+			{
+				return $gid;
+			}
+			// Something went wrong
+			else
+			{
+				return MYBB_REGISTERED;
+			}
+		}
+	}
+}
 ?>

--- a/resources/class_converter_module.php
+++ b/resources/class_converter_module.php
@@ -116,11 +116,11 @@ class Converter_Module
 		}
 	}
 
-	function increment_tracker($type)
+	function increment_tracker($type, $amount=1)
 	{
 		global $db;
 
-		++$this->trackers['start_'.$type];
+		$this->trackers['start_'.$type] += $amount;
 
 		$db->write_query("REPLACE INTO ".TABLE_PREFIX."trackers SET count=".intval($this->trackers['start_'.$type]).", type='".$db->escape_string($type)."'");
 	}


### PR DESCRIPTION
#47

I've added a `$groups` array to the different boards which contains all default groups (old_id => mybb_id) and added a function to the main boards class which resolves a gid by first checking the new array, then asking the cache about custom groups (like it was done before). I've also modified the `get_group_id` functions to use that function instead of a big switch (#101).

The forumpermissions module(s) were only checking custom groups, I've edited them to use the new function to also resolve the default ones. In addition I've fixed a bug within the phpBB module which ended in countless useless redirects.

Probably fixed a few more things I've forgotten.
@mybb/sqa @Sama34 @JovanJ Please test this ASAP as it will easily get merge conflicts.
