### PR TITLE
Fixes #45 SMF 2 Poll Votes not converted properly

### DIFF
--- a/boards/smf2/polls.php
+++ b/boards/smf2/polls.php
@@ -49,6 +49,7 @@ class SMF2_Converter_Module_Polls extends Converter_Module_Polls {
 		$thread = $this->get_poll_thread($data['id_poll']);
 
 		$insert_data['import_tid'] = $thread['import_tid'];
+		$insert_data['import_pid'] = $data['id_poll'];
 		$insert_data['tid'] = $thread['tid'];
 		$insert_data['dateline'] = $thread['dateline'];
 


### PR DESCRIPTION
#45

The `import_pid` column wasn't set so the poll votes module failed
