### PR TITLE
Fixes #14 [attachment] codes

### DIFF
--- a/boards/ipb3/bbcode_parser.php
+++ b/boards/ipb3/bbcode_parser.php
@@ -15,6 +15,9 @@ if(!defined("IN_MYBB"))
 
 class BBCode_Parser extends BBCode_Parser_HTML {
 
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attachment=([0-9]+):(.*?)\]";
+
 	/**
 	 * Unconvert the HTML in posts, back to BBCode
 	 * @param ref parser object

--- a/boards/mybb/bbcode_parser.php
+++ b/boards/mybb/bbcode_parser.php
@@ -13,10 +13,17 @@ if(!defined("IN_MYBB"))
 	die("Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.");
 }
 
-class BBCode_Parser {
+class BBCode_Parser extends BBCode_Parser_Plain {
 
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attachment=([0-9]+)\]";
+
+	// Overwrite the old function - no need for it
 	function convert($message)
 	{
+		// But call the attachments functions
+		$message = $this->handle_attachments($message);
+
 		return $message;
 	}
 }

--- a/boards/mybb/posts.php
+++ b/boards/mybb/posts.php
@@ -73,7 +73,7 @@ class MYBB_Converter_Module_Posts extends Converter_Module_Posts {
 		$insert_data['uid'] = $this->get_import->uid($data['uid']);
 		$insert_data['username'] = $this->get_import->username($data['uid']);
 		$insert_data['subject'] = encode_to_utf8($data['subject'], "posts", "posts");
-		$insert_data['message'] = encode_to_utf8($data['message'], "posts", "posts");
+		$insert_data['message'] = encode_to_utf8($this->bbcode_parser->convert($data['message']), "posts", "posts");
 
 		return $insert_data;
 	}

--- a/boards/phpbb3/posts.php
+++ b/boards/phpbb3/posts.php
@@ -47,7 +47,7 @@ class PHPBB3_Converter_Module_Posts extends Converter_Module_Posts {
 		$insert_data['import_uid'] = $data['poster_id'];
 		$insert_data['username'] = $this->get_import->username($data['poster_id'], $data['post_username']);
 		$insert_data['dateline'] = $data['post_time'];
-		$insert_data['message'] = encode_to_utf8($this->bbcode_parser->convert($data['post_text'], $data['bbcode_uid']), "posts", "posts");
+		$insert_data['message'] = encode_to_utf8($this->bbcode_parser->convert($data['post_text'], $data['bbcode_uid'], $data['post_id']), "posts", "posts");
 		$insert_data['ipaddress'] = my_inet_pton($data['poster_ip']);
 		$insert_data['includesig'] = $data['enable_sig'];
 		$insert_data['smilieoff'] = int_to_01($data['enable_smilies']);

--- a/boards/vbulletin3/bbcode_parser.php
+++ b/boards/vbulletin3/bbcode_parser.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * MyBB 1.8 Merge System
- * Copyright 2011 MyBB Group, All Rights Reserved
+ * Copyright 2014 MyBB Group, All Rights Reserved
  *
  * Website: http://www.mybb.com
- * License: http://www.mybb.com/about/license
+ * License: http://www.mybb.com/download/merge-system/license/
  */
 
 // Disallow direct access to this file for security reasons
@@ -13,86 +13,35 @@ if(!defined("IN_MYBB"))
 	die("Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.");
 }
 
-class BBCode_Parser {
+class BBCode_Parser extends BBCode_Parser_Plain {
+
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attach\]([0-9]+)\[/attach\]";
 
 	function convert($text)
 	{
 		$find = array(
-			'[CENTER]',
-			'[/CENTER]',
-			'[LEFT]',
-			'[/LEFT]',
-			'[RIGHT]',
-			'[/RIGHT]',
-			'[QUOTE]',
-			'[/QUOTE]',
-			'[B]',
-			'[/B]',
-			'[PHP]',
-			'[/PHP]',
-			'[URL',
-			'[/URL]',
-			'[I]',
-			'[/I]',
-			'[U]',
-			'[/U]',
-			'[IMG]',
-			'[/IMG]',
-			'[/QUOTE]',
-		);
-
-		$replace = array(
-			'[align=center]',
-			'[/align]',
-			'[align=left]',
-			'[/align]',
-			'[align=right]',
-			'[/align]',
-			'[quote]',
-			'[/quote]',
-			'[b]',
-			'[/b]',
-			'[php]',
-			'[/php]',
-			'[url',
-			'[/url]',
-			'[i]',
-			'[/i]',
-			'[u]',
-			'[/u]',
-			'[img]',
-			'[/img]',
-			'[/quote]',
-		);
-
-		if(function_exists("str_ireplace"))
-		{
-			$text = str_ireplace($find, $replace, $text);
-		}
-		else
-		{
-			$text = str_replace($find, $replace, $text);
-		}
-
-		$find = array(
-			'#\[COLOR\="(.*?)"\](.*?)\[/COLOR\]#i', // TODO: Test?!
-			'#\[COLOR\=(.*?)\](.*?)\[/COLOR\]#i',
+			'#\[COLOR\="([a-zA-Z]*|\#?[\da-fA-F]{3}|\#?[\da-fA-F]{6})"\](.*?)\[/COLOR\]#i',
 			'#\[QUOTE\=(.*?);([0-9]+?)\]#i',
 			'#\[url\="(.*?)"](.*?)\[/url\]#i',
-			'#\[url\=(.*?)](.*?)\[/url\]#i',
+			'#\[email\="(.*?)"](.*?)\[/email\]#i',
+			'#\[size\="(.*?)"](.*?)\[/size\]#i',
 		);
 
 		$replace = array(
-			'[color=$1]$2[/color]',
 			'[color=$1]$2[/color]',
 			"[quote=$1]",
 			'[url=$1]$2[/url]',
-			'[url=$1]$2[/url]',
+			'[email=$1]$2[/email]',
+			'[size=$1]$2[/size]',
 		);
 
 		$text = preg_replace($find, $replace, $text);
 
-		return $text;
+		// Closing line tags
+		$text = str_ireplace("[/hr]", "", $text);
+
+		return parent::convert($text);
 	}
 }
 ?>

--- a/boards/vbulletin4/bbcode_parser.php
+++ b/boards/vbulletin4/bbcode_parser.php
@@ -13,86 +13,33 @@ if(!defined("IN_MYBB"))
 	die("Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.");
 }
 
-class BBCode_Parser {
+class BBCode_Parser extends BBCode_Parser_Plain {
+
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attach\]([0-9]+)\[/attach\]";
 
 	function convert($text)
 	{
 		$find = array(
-			'[CENTER]',
-			'[/CENTER]',
-			'[LEFT]',
-			'[/LEFT]',
-			'[RIGHT]',
-			'[/RIGHT]',
-			'[QUOTE]',
-			'[/QUOTE]',
-			'[B]',
-			'[/B]',
-			'[PHP]',
-			'[/PHP]',
-			'[URL',
-			'[/URL]',
-			'[I]',
-			'[/I]',
-			'[U]',
-			'[/U]',
-			'[IMG]',
-			'[/IMG]',
-			'[/QUOTE]',
-		);
-
-		$replace = array(
-			'[align=center]',
-			'[/align]',
-			'[align=left]',
-			'[/align]',
-			'[align=right]',
-			'[/align]',
-			'[quote]',
-			'[/quote]',
-			'[b]',
-			'[/b]',
-			'[php]',
-			'[/php]',
-			'[url',
-			'[/url]',
-			'[i]',
-			'[/i]',
-			'[u]',
-			'[/u]',
-			'[img]',
-			'[/img]',
-			'[/quote]',
-		);
-
-		if(function_exists("str_ireplace"))
-		{
-			$text = str_ireplace($find, $replace, $text);
-		}
-		else
-		{
-			$text = str_replace($find, $replace, $text);
-		}
-
-		$find = array(
-			'#\[COLOR\="(.*?)"\](.*?)\[/COLOR\]#i', // TODO: Test?!
-			'#\[COLOR\=(.*?)\](.*?)\[/COLOR\]#i',
+			'#\[COLOR\="([a-zA-Z]*|\#?[\da-fA-F]{3}|\#?[\da-fA-F]{6})"\](.*?)\[/COLOR\]#i',
 			'#\[QUOTE\=(.*?);([0-9]+?)\]#i',
 			'#\[url\="(.*?)"](.*?)\[/url\]#i',
-			'#\[url\=(.*?)](.*?)\[/url\]#i',
+			'#\[email\="(.*?)"](.*?)\[/email\]#i',
 		);
 
 		$replace = array(
-			'[color=$1]$2[/color]',
 			'[color=$1]$2[/color]',
 			"[quote=$1]",
 			'[url=$1]$2[/url]',
-			'[url=$1]$2[/url]',
+			'[email=$1]$2[/email]',
 		);
 
 		$text = preg_replace($find, $replace, $text);
 
-		return $text;
+		// Closing line tags
+		$text = str_ireplace("[/hr]", "", $text);
+
+		return parent::convert($text);
 	}
 }
 ?>

--- a/boards/wbb3/bbcode_parser.php
+++ b/boards/wbb3/bbcode_parser.php
@@ -13,10 +13,15 @@ if(!defined("IN_MYBB"))
 	die("Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.");
 }
 
-class BBCode_Parser {
+class BBCode_Parser extends BBCode_Parser_Plain {
+
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attach\]([0-9]+)\[/attach\]";
 
 	function convert($message)
 	{
+		$message =  $this->handle_attachments($message);
+
 		// You won't believe it: WBB uses the same mycodes like we do!
 		return $message;
 	}

--- a/boards/wbb4/bbcode_parser.php
+++ b/boards/wbb4/bbcode_parser.php
@@ -13,10 +13,19 @@ if(!defined("IN_MYBB"))
 	die("Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.");
 }
 
-class BBCode_Parser {
+class BBCode_Parser extends BBCode_Parser_Plain {
+
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attach=([0-9]+)\](\[/attach\])?";
 
 	function convert($message)
 	{
+		// As WBB changed the attach bbcode they support three different type: "[attach={id}]", "[attach={id}][/attach]", "[attach]{id}[/attach]"
+		// The first two are handled by the regex above, however the third one needs to be changed to the first so the handle_attachment function detects it
+		$message = preg_replace("#\[attach\]([0-9]+)\[/attach\]#i", "[attach=$1]", $message);
+
+		$message = $this->handle_attachments($message);
+
 		// You won't believe it: WBB uses the same mycodes like we do!
 		return $message;
 	}

--- a/boards/xenforo/bbcode_parser.php
+++ b/boards/xenforo/bbcode_parser.php
@@ -15,8 +15,14 @@ if(!defined("IN_MYBB"))
 
 class BBCode_Parser extends BBCode_Parser_Plain {
 
+	// This contains the attachment bbcode which is handled as special code as the id needs to be changed too
+	var $attachment = "\[attach\]([0-9]+)\[/attach\]";
+
 	function convert($text)
 	{
+		// Attachment codes have an optional full parameter which we need to remove
+		$text = str_ireplace("[attach=full]", "[attach]", $text);
+
 		$text = parent::convert($text);
 
 		$text = preg_replace("#\[html\](.*?)\[/html\]#si", "[php]$1[/php]", $text);

--- a/index.php
+++ b/index.php
@@ -688,6 +688,14 @@ elseif(isset($mybb->input['action']) && $mybb->input['action'] == 'finish')
 	$cache->update_usertitles();
 	$output->update_progress_bar(180);
 
+	// Replaces orphaned attachment codes with "[ATTACHMENT NOT FOUND]"
+	$query = $db->simple_select("posts", "pid,message", "message LIKE '%[attachment=o%'");
+	while($post = $db->fetch_array($query))
+	{
+		$message = preg_replace("#\[attachment=o([0-9]+)\]#i", "[ATTACHMENT NOT FOUND]", $post['message']);
+		$db->update_query("posts", array("message" => $message), "pid={$post['pid']}");
+	}
+
 	// Update import session cache
 	$import_session['end_date'] = time();
 

--- a/resources/bbcode_html.php
+++ b/resources/bbcode_html.php
@@ -45,6 +45,8 @@ class BBCode_Parser_HTML extends BBCode_Parser_Plain {
 		$text = preg_replace('#<ol>(.*?)</ol>#si', "[list=1]$1[/list]", $text);
 		$text = preg_replace('#<li>(.*?)</li>#si', "[*]$1", $text);
 
+		$text = $this->handle_attachments($text);
+
 		return $text;
 	}
 

--- a/resources/modules/attachments.php
+++ b/resources/modules/attachments.php
@@ -66,6 +66,10 @@ class Converter_Module_Attachments extends Converter_Module
 		$db->insert_query("attachments", $insert_array);
 		$aid = $db->insert_id();
 
+		// Let's change the bbcodes for this attachment
+		$insert_array['aid'] = $aid;
+		$this->bbcode_parser->change_attachment($insert_array);
+
 		if(!defined("IN_TESTING"))
 		{
 			$this->after_insert($unconverted_values, $converted_values, $aid);


### PR DESCRIPTION
#14

This PR changes the BBCode Parser so, that it changes all attachment codes to `[attachment=o{oldid}]`. Afterwards the attachment module changes the id to the new one. The cleanup page replaces all old codes (eg missing attachment or attachment module not run) to `[ATTACHMENT NOT FOUND]`.

Also changed the vB parsers to make use of the new parser classes.
