### PR TITLE
Fix 'unknown column m.id' error when migrating moderators for IPB 3

### DIFF
--- a/boards/ipb3/moderators.php
+++ b/boards/ipb3/moderators.php
@@ -26,7 +26,7 @@ class IPB3_Converter_Module_Moderators extends Converter_Module_Moderators {
 		global $import_session, $db;
 
 		$query = $this->old_db->query("
-			SELECT mr.*, IF(mr.is_group = 1, m.id, mr.member_id) as member_id
+			SELECT mr.*, IF(mr.is_group = 1, m.member_id, mr.member_id) as member_id
 			FROM ".OLD_TABLE_PREFIX."moderators mr
 			LEFT JOIN ".OLD_TABLE_PREFIX."members m ON(mr.group_id = m.mgroup)
 			LIMIT {$this->trackers['start_moderators']}, {$import_session['moderators_per_screen']}

--- a/boards/ipb3/moderators.php
+++ b/boards/ipb3/moderators.php
@@ -28,7 +28,7 @@ class IPB3_Converter_Module_Moderators extends Converter_Module_Moderators {
 		$query = $this->old_db->query("
 			SELECT mr.*, IF(mr.is_group = 1, m.member_id, mr.member_id) as member_id
 			FROM ".OLD_TABLE_PREFIX."moderators mr
-			LEFT JOIN ".OLD_TABLE_PREFIX."members m ON(mr.group_id = m.mgroup)
+			LEFT JOIN ".OLD_TABLE_PREFIX."members m ON(mr.group_id = m.member_group_id)
 			LIMIT {$this->trackers['start_moderators']}, {$import_session['moderators_per_screen']}
 		");
 		while($moderator = $this->old_db->fetch_array($query))


### PR DESCRIPTION
Currently moderators migration results in:

MyBB has experienced an internal SQL error and cannot continue.

SQL Error:
`1054 - Unknown column 'm.id' in 'field list'` (or `mgroup`)
Query:
`SELECT mr.*, IF(mr.is_group = 1, m.id, mr.member_id) as member_id FROM moderators mr LEFT JOIN members m ON(mr.group_id = m.mgroup) LIMIT 0, 1000`

Please contact the MyBB Group for technical support.
