### PR TITLE
Replaced /e modifier with preg_replace_callback

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -727,8 +727,8 @@ if(!function_exists('htmlspecialchars_decode'))
 function utf8_unhtmlentities($string)
 {
 	// Replace numeric entities
-	$string = preg_replace('~&#x([0-9a-f]+);~ei', 'unichr(hexdec("\\1"))', $string);
-	$string = preg_replace('~&#([0-9]+);~e', 'unichr("\\1")', $string);
+	$string = preg_replace_callback('~&#x([0-9a-f]+);~i', function ($matches) { return unichr(hexdec($matches[1])); }, $string);
+	$string = preg_replace_callback('~&#([0-9]+);~', function ($matches) { return unichr($matches[1]); }, $string);
 
 	// Replace literal entities
 	$trans_tbl = get_html_translation_table(HTML_ENTITIES);

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -727,8 +727,8 @@ if(!function_exists('htmlspecialchars_decode'))
 function utf8_unhtmlentities($string)
 {
 	// Replace numeric entities
-	$string = preg_replace_callback('~&#x([0-9a-f]+);~i', function ($matches) { return unichr(hexdec($matches[1])); }, $string);
-	$string = preg_replace_callback('~&#([0-9]+);~', function ($matches) { return unichr($matches[1]); }, $string);
+	$string = preg_replace_callback('~&#x([0-9a-f]+);~i', create_function('$matches', 'return unichr(hexdec($matches[1]));'), $string);
+	$string = preg_replace_callback('~&#([0-9]+);~', create_function('$matches', 'return unichr($matches[1]);'), $string);
 
 	// Replace literal entities
 	$trans_tbl = get_html_translation_table(HTML_ENTITIES);


### PR DESCRIPTION
Support for the /e modifier has been removed in PHP7.
