### PR TITLE
Fix IPB3 Merge Fail

### DIFF
--- a/boards/ipb3/moderators.php
+++ b/boards/ipb3/moderators.php
@@ -26,9 +26,9 @@ class IPB3_Converter_Module_Moderators extends Converter_Module_Moderators {
 		global $import_session, $db;
 
 		$query = $this->old_db->query("
-			SELECT mr.*, IF(mr.is_group = 1, m.id, mr.member_id) as member_id
+			SELECT mr.*, IF(mr.is_group = 1, m.member_id, mr.member_id) as member_id
 			FROM ".OLD_TABLE_PREFIX."moderators mr
-			LEFT JOIN ".OLD_TABLE_PREFIX."members m ON(mr.group_id = m.mgroup)
+			LEFT JOIN ".OLD_TABLE_PREFIX."members m ON(mr.group_id = m.member_group_id)
 			LIMIT {$this->trackers['start_moderators']}, {$import_session['moderators_per_screen']}
 		");
 		while($moderator = $this->old_db->fetch_array($query))


### PR DESCRIPTION
The merge fails on moderators because of incorrect column names. This change corrects that. The merge is still a bit buggy but at least it won't outright fail now.