### PR TITLE
Ensuring unique attachment file names

### DIFF
--- a/boards/vbulletin3/attachments.php
+++ b/boards/vbulletin3/attachments.php
@@ -110,7 +110,7 @@ class VBULLETIN3_Converter_Module_Attachments extends Converter_Module_Attachmen
 
 		$insert_data['uid'] = $this->get_import->uid($data['userid']);
 		$insert_data['filename'] = $data['filename'];
-		$insert_data['attachname'] = "post_".$insert_data['uid']."_".$data['dateline'].".attach";
+		$insert_data['attachname'] = "post_".$insert_data['uid']."_".$data['dateline']."_".$data['attachmentid'].".attach";
 		$insert_data['filesize'] = $data['filesize'];
 		$insert_data['downloads'] = $data['counter'];
 		$insert_data['visible'] = $data['visible'];


### PR DESCRIPTION
As "User Id + Date" are not guaranteed to be unique for attachment file names (eg. in case a user attached multiple files to a single post at once), including the original attachment Id in the file name as well.

This fixed an issue while performing a merge on our board, where previously imported files were overwritten due to the fact that the new file name was identical.