### PR TITLE
Fix some problems in the base posts module

### DIFF
--- a/resources/modules/posts.php
+++ b/resources/modules/posts.php
@@ -112,7 +112,10 @@ abstract class Converter_Module_Posts extends Converter_Module
 		}
 
 		// General output and our progress bar can be constructed here
-		$output->print_header($lang->module_post_rebuilding);
+		if(!$output->doneheader)
+		{
+			$output->print_header($lang->module_post_rebuilding);
+		}
 
 		$this->debug->log->trace0("Rebuilding thread, forum, and statistic counters");
 
@@ -141,6 +144,10 @@ abstract class Converter_Module_Posts extends Converter_Module
 		$num_imported_threads = $db->fetch_field($query, "count");
 		$last_percent = 0;
 
+		if(!isset($import_session['counters_threads_start']))
+		{
+			$import_session['counters_threads_start'] = 0;
+		}
 		// Have we finished already (redirects...)?
 		if($import_session['counters_threads_start'] >= $num_imported_threads) {
 			return;
@@ -151,7 +158,8 @@ abstract class Converter_Module_Posts extends Converter_Module
 		flush();
 
 		// Get all threads for this page (1000 per page)
-		$progress = $import_session['counters_threads_start'];
+		$progress = 0;
+		$progress_total = $import_session['counters_threads_start'];
 		$query = $db->simple_select("threads", "tid", "import_tid > 0", array('order_by' => 'tid', 'order_dir' => 'asc', 'limit_start' => (int)$import_session['counters_threads_start'], 'limit' => 1000));
 		while($thread = $db->fetch_array($query))
 		{
@@ -160,17 +168,18 @@ abstract class Converter_Module_Posts extends Converter_Module
 
 			// Now inform the user
 			++$progress;
-
+			++$progress_total;
+			
 			// Code comes from Dylan, probably has a reason, simply leave it there
-			if(($progress % 5) == 0)
+			if(($progress_total % 5) == 0)
 			{
-				if(($progress % 100) == 0)
+				if(($progress_total % 100) == 0)
 				{
 					check_memory();
 				}
 
 				// 200 is maximum for the progress bar so *200 and not *100
-				$percent = round(($progress/$num_imported_threads)*200, 1);
+				$percent = round(($progress_total/$num_imported_threads)*200, 1);
 				if($percent != $last_percent)
 				{
 					$output->update_progress_bar($percent, $lang->sprintf($lang->module_post_thread_counter, $thread['tid']));


### PR DESCRIPTION
1. In the `cleanup()` of the `posts` module, set the output header only if it's not been set, to avoid double headers appear.
1. Still in the `cleanup()` of the `posts` module, fix the the internal progress indicator to make `rebuild_thread_counters()` working correctly.