### PR TITLE
Resolve #229, add customized board module support.

### DIFF
--- a/index.php
+++ b/index.php
@@ -879,7 +879,21 @@ elseif($import_session['module'] && $mybb->input['action'] != 'module_list')
 		$module_name = str_replace(array("import_", ".", ".."), "", $import_session['module']);
 
 		require_once MERGE_ROOT.'resources/class_converter_module.php';
-		require_once MERGE_ROOT."resources/modules/{$module_name}.php";
+		// Allow customized import_ modules derived from MyBB Merge System's base abstract class.
+		// Use string "__none__" to directly derived from the Converter_Module class, or specify a base module's class name, or leave it empty/unset.
+		// This would be useful if you have difficulty having your job done for only one time in a module. But write your own module class with '__none__' class_depencencies would be better.
+		if(isset($board->modules[$import_session['module']]['class_depencencies']) && !empty($board->modules[$import_session['module']]['class_depencencies']))
+		{
+			$module_dep_classname = $board->modules[$import_session['module']]['class_depencencies'];
+			if($module_dep_classname != "__none__")
+			{
+				require_once MERGE_ROOT."resources/modules/{$module_dep_classname}.php";
+			}
+		}
+		else
+		{
+			require_once MERGE_ROOT."resources/modules/{$module_name}.php";
+		}
 		require_once MERGE_ROOT."boards/{$import_session['board']}/{$module_name}.php";
 
 		$importer_class_name = strtoupper($import_session['board'])."_Converter_Module_".ucfirst($module_name);


### PR DESCRIPTION
I separated this from my [last PR](https://github.com/mybb/merge-system/pull/230) to a new commit, so we can have a clear judge and commit history.

The way to add customized board module support is quite primitive but workable. See #229 for a demo result of merging some customized board modules.

PS, oh, I finally got rid of the PR commits when I pull from upstream in my fork. That's really annoying if I want to maintain my own fork. I'm also working on the Discuz! X2.5 Discuz! UCenter converters branch to make its commit history clean.