### PR TITLE
Remove discontinued "yahoo" contact information field.

### DIFF
--- a/boards/fluxbb/users.php
+++ b/boards/fluxbb/users.php
@@ -58,7 +58,6 @@ class FLUXBB_Converter_Module_Users extends Converter_Module_Users {
 
 		$insert_data['lastpost'] = (int)$data['last_post'];
 		$insert_data['icq'] = $data['icq'];
-		$insert_data['yahoo'] = $data['yahoo'];
 		$insert_data['hideemail'] = $data['email_setting'];
 		$insert_data['allownotices'] = $data['notify_with_post'];
 		$insert_data['regip'] = my_inet_pton($data['registration_ip']);

--- a/boards/ipb3/users.php
+++ b/boards/ipb3/users.php
@@ -68,7 +68,6 @@ class IPB3_Converter_Module_Users extends Converter_Module_Users {
 			$insert_data['birthday'] = $data['bday_day'].'-'.$data['bday_month'].'-'.$data['bday_year'];
 		}
 		$insert_data['icq'] = $data['field_4'];
-		$insert_data['yahoo'] = $data['field_8'];
 		$insert_data['skype'] = $data['field_10'];
 		$insert_data['timezone'] = str_replace(array('.0', '.00'), array('', ''), $data['time_offset']);
 		$insert_data['timezone'] = ((!strstr($insert_data['timezone'], '+') && !strstr($insert_data['timezone'], '-')) ? '+'.$insert_data['timezone'] : $insert_data['timezone']);

--- a/boards/phpbb3/users.php
+++ b/boards/phpbb3/users.php
@@ -97,7 +97,6 @@ class PHPBB3_Converter_Module_Users extends Converter_Module_Users {
 
 		$insert_data['birthday'] = $birthday;
 		$insert_data['icq'] = $data['user_icq'];
-		$insert_data['yahoo'] = $data['user_yim'];
 		$insert_data['hideemail'] = $data['user_allow_viewemail'];
 		$insert_data['invisible'] = int_to_01($data['user_allow_viewonline']);
 		$insert_data['allownotices'] = $data['user_notify'];

--- a/boards/punbb/users.php
+++ b/boards/punbb/users.php
@@ -77,7 +77,6 @@ class PUNBB_Converter_Module_Users extends Converter_Module_Users {
 
 		$insert_data['lastpost'] = $data['last_post'];
 		$insert_data['icq'] = $data['icq'];
-		$insert_data['yahoo'] = $data['yahoo'];
 		$insert_data['hideemail'] = $data['email_setting'];
 		$insert_data['allownotices'] = $data['notify_with_post'];
 		$insert_data['regip'] = my_inet_pton($data['registration_ip']);

--- a/boards/smf/users.php
+++ b/boards/smf/users.php
@@ -71,7 +71,6 @@ class SMF_Converter_Module_Users extends Converter_Module_Users {
 			$insert_data['birthday'] = date("j-n-Y", strtotime($data['birthdate']));
 		}
 		$insert_data['icq'] = $data['ICQ'];
-		$insert_data['yahoo'] = $data['YIM'];
 		$insert_data['hideemail'] = $data['hideEmail'];
 		$insert_data['invisible'] = int_to_01($data['showOnline']);
 		$insert_data['pmnotify'] = $data['pm_email_notify'];

--- a/boards/smf2/users.php
+++ b/boards/smf2/users.php
@@ -71,7 +71,6 @@ class SMF2_Converter_Module_Users extends Converter_Module_Users {
 			$insert_data['birthday'] = date("j-n-Y", strtotime($data['birthdate']));
 		}
 		$insert_data['icq'] = $data['icq'];
-		$insert_data['yahoo'] = $data['yim'];
 		$insert_data['hideemail'] = $data['hide_email'];
 		$insert_data['invisible'] = int_to_01($data['show_online']);
 		$insert_data['pmnotify'] = $data['pm_email_notify'];

--- a/boards/vbulletin3/users.php
+++ b/boards/vbulletin3/users.php
@@ -89,7 +89,6 @@ class VBULLETIN3_Converter_Module_Users extends Converter_Module_Users {
 			$insert_data['birthday'] = $data['birthday'];
 		}
 		$insert_data['icq'] = $data['icq'];
-		$insert_data['yahoo'] = $data['yahoo'];
 		$insert_data['timezone'] = str_replace(array('.0', '.00'), array('', ''), $insert_data['timezone']);
 		$insert_data['style'] = 0;
 		$insert_data['referrer'] = $data['referrerid'];

--- a/boards/vbulletin4/users.php
+++ b/boards/vbulletin4/users.php
@@ -72,7 +72,6 @@ class VBULLETIN4_Converter_Module_Users extends Converter_Module_Users {
 			$insert_data['birthday'] = $bday."-".$bmonth."-".$byear;
 		}
 		$insert_data['icq'] = $data['icq'];
-		$insert_data['yahoo'] = $data['yahoo'];
 		$insert_data['skype'] = $data['skype'];
 		$insert_data['timezone'] = str_replace(array('.0', '.00'), array('', ''), $insert_data['timezone']);
 		$insert_data['style'] = 0;

--- a/boards/vbulletin5/users.php
+++ b/boards/vbulletin5/users.php
@@ -72,7 +72,6 @@ class VBULLETIN5_Converter_Module_Users extends Converter_Module_Users {
 			$insert_data['birthday'] = $bday."-".$bmonth."-".$byear;
 		}
 		$insert_data['icq'] = $data['icq'];
-		$insert_data['yahoo'] = $data['yahoo'];
 		$insert_data['skype'] = $data['skype'];
 		$insert_data['timezone'] = str_replace(array('.0', '.00'), array('', ''), $insert_data['timezoneoffset']);
 		$insert_data['style'] = 0;

--- a/resources/modules/users.php
+++ b/resources/modules/users.php
@@ -35,7 +35,6 @@ abstract class Converter_Module_Users extends Converter_Module
 		'avatar' => '',
 		'lastpost' => 0,
 		'icq' => '',
-		'yahoo' => '',
 		'skype' => '',
 		'google' => '',
 		'hideemail' => 1,


### PR DESCRIPTION
Mentioned in #240, the additional contact information field `yahoo` is removed in MyBB 1.8.22: https://github.com/mybb/mybb/issues/3695 .

Discontinued "yahoo" contact information field is removed from users base module.
All relevant boards' users modules are also updated.
No setting modules dealing with `allowyahoofield` are spotted thus no additional removal.