### PR TITLE
Fix #243 `parentlist` is not properly set for root categories in MyBB forums module

### DIFF
--- a/boards/mybb/forums.php
+++ b/boards/mybb/forums.php
@@ -93,14 +93,14 @@ class MYBB_Converter_Module_Forums extends Converter_Module_Forums  {
 	{
 		global $db;
 
-		// Imported root Category forums (type 'c' forums whose parent is "None").
+		// Cleanup root category forums (type 'c' forums whose parent is "None").
 		$query = $db->simple_select("forums", "fid", "import_fid != '0' AND import_pid = '0'");
 		while($forum = $db->fetch_array($query))
 		{
 			$db->update_query("forums", array('parentlist' => $forum['fid']), "fid='{$forum['fid']}'", 1);
 		}
 
-		// Ohter imported forums.
+		// Cleanup other imported forums
 		$query = $db->query("
 			SELECT f.fid, f.import_fid, f2.fid as updatefid
 			FROM ".TABLE_PREFIX."forums f
@@ -115,5 +115,4 @@ class MYBB_Converter_Module_Forums extends Converter_Module_Forums  {
 		parent::cleanup();
 	}
 }
-
 


### PR DESCRIPTION
Resolves #243.

Deleted following code in MyBB forums module which is not really needed I suppose:
```
		// This value NEEDS to be here for the cleanup() to work
		$insert_data['pid'] = 0;
```