### PR TITLE
Avoid trimming data when we can't guess the column length

### DIFF
--- a/resources/class_converter_module.php
+++ b/resources/class_converter_module.php
@@ -172,7 +172,7 @@ abstract class Converter_Module
 					$insert_field_length -= 1;
 					$insert_field_negative_int = true;
 				}
-				if($insert_field_length > $column_length[$key]) {
+				if(in_array($key, $column_length) && $column_length[$key] !== 0 && $insert_field_length > $column_length[$key]) {
 					if(is_int($insert_array[$key])) {
 						// TODO: check whether int(10) really can save "9999999999" as maximum
 						$insert_array[$key] = ($insert_field_negative_int ? '-' : '') . str_repeat('9', $column_length[$key]);


### PR DESCRIPTION
The merge system can't guess the column length properly when importing to a postgres db, as a result the last three characters were being replaced by `...`:

`my_substr($insert_array[$key], 0, $column_length[$key]-3)."..."; // $column_length[$key] is 0`

We had this problem while importing a ipb4 forum (mysql) to mybb (postgres). This commit should make it more obvious and prevent trimming data when the column length is not known.

