### PR TITLE
Handle binary data in datatrace method

### DIFF
--- a/resources/class_debug.php
+++ b/resources/class_debug.php
@@ -108,7 +108,30 @@ class Log {
 	 */
 	public function datatrace($message, $data)
 	{
-		$this->write(self::DATATRACE, $message.': '.var_export($data, true));
+		$insert_data = $data;
+		if(is_array($insert_data))
+		{
+			foreach ($data as $key => $value)
+			{
+				if(is_string($value) && false === preg_match('//u', $value))
+				{
+					// the value is likely binary data. We'll try converting it to an IP first and if that fails we'll just set the field to blank.
+					$ip = inet_ntop($value);
+					if(false === $ip)
+					{
+						$value = '';
+					}
+					else
+					{
+						$value = $ip;
+					}
+				}
+
+				$insert_data[$key] = $value;
+			}
+		}
+
+		$this->write(self::DATATRACE, $message.': '.var_export($insert_data, true));
 	}
 
 	/**


### PR DESCRIPTION
Resolves #235 as proposed in https://github.com/mybb/merge-system/issues/235#issuecomment-766391956.

This will attempt to handle binary data by trying to convert it to an IP address (probably the most likely case) and in other cases stores an empty string for the field.