### PR TITLE
Vanilla fixes, and improved UTF-8 handling

### DIFF
--- a/boards/vanilla/forums.php
+++ b/boards/vanilla/forums.php
@@ -107,7 +107,7 @@ class VANILLA_Converter_Module_Forums extends Converter_Module_Forums {
 		$query = $db->query("
 			SELECT f.fid, f2.fid as updatefid, f.import_fid
 			FROM ".TABLE_PREFIX."forums f
-			LEFT JOIN ".TABLE_PREFIX."forums f2 ON (f2.import_fid=f.import_pid)
+			INNER JOIN ".TABLE_PREFIX."forums f2 ON (f2.import_fid=f.import_pid)
 			WHERE f.import_pid != 0 AND f.pid = 0
 		");
 		while($forum = $db->fetch_array($query))

--- a/boards/vanilla/privatemessages.php
+++ b/boards/vanilla/privatemessages.php
@@ -44,6 +44,9 @@ class VANILLA_Converter_Module_Privatemessages extends Converter_Module_Privatem
 		// Vanilla values
 		$recip = unserialize($data['recips']);
 		$to_send = array();
+		if (!is_array($recip) || empty($recip)) {
+			return array();
+		}
 		foreach($recip as $key => $id)
 		{
 			$recip[$key] = $this->get_import->uid($id);

--- a/boards/vanilla/privatemessages.php
+++ b/boards/vanilla/privatemessages.php
@@ -27,7 +27,8 @@ class VANILLA_Converter_Module_Privatemessages extends Converter_Module_Privatem
 
 		$query = $this->old_db->query("SELECT m.*, pm.Subject, pm.Contributors AS recips
 			FROM ".OLD_TABLE_PREFIX."conversationmessage m
-			LEFT JOIN ".OLD_TABLE_PREFIX."conversation pm ON(pm.ConversationID=m.ConversationID)
+			INNER JOIN ".OLD_TABLE_PREFIX."conversation pm ON(pm.ConversationID=m.ConversationID)
+			WHERE pm.Contributors <> '' AND pm.Contributors IS NOT NULL
 			LIMIT {$this->trackers['start_privatemessages']}, {$import_session['privatemessages_per_screen']}");
    		while($privatemessage = $this->old_db->fetch_array($query))
 		{
@@ -44,9 +45,6 @@ class VANILLA_Converter_Module_Privatemessages extends Converter_Module_Privatem
 		// Vanilla values
 		$recip = unserialize($data['recips']);
 		$to_send = array();
-		if (!is_array($recip) || empty($recip)) {
-			return array();
-		}
 		foreach($recip as $key => $id)
 		{
 			$recip[$key] = $this->get_import->uid($id);
@@ -146,7 +144,10 @@ class VANILLA_Converter_Module_Privatemessages extends Converter_Module_Privatem
 		// Get number of private messages
 		if(!isset($import_session['total_privatemessages']))
 		{
-			$query = $this->old_db->simple_select("conversationmessage", "COUNT(*) as count");
+			$query = $this->old_db->query("SELECT COUNT(*) AS count
+			FROM ".OLD_TABLE_PREFIX."conversationmessage m
+			INNER JOIN ".OLD_TABLE_PREFIX."conversation pm ON(pm.ConversationID=m.ConversationID)
+			WHERE pm.Contributors <> '' AND pm.Contributors IS NOT NULL");
 			$import_session['total_privatemessages'] = $this->old_db->fetch_field($query, 'count');
 			$this->old_db->free_result($query);
 		}

--- a/resources/class_debug.php
+++ b/resources/class_debug.php
@@ -168,6 +168,17 @@ class Log {
 				if(strlen($log_insert['message']) > 65535)
 				{
 					$log_insert['message'] = substr($log_insert['message'], 0, 65531)."...";
+
+					// check that the content is valid UTF-8 - we may have sliced part-way into a unicode codepoint
+					if (!preg_match('//u', $log_insert['message'])) {
+						if (function_exists('mb_convert_encoding')) {
+							$log_insert['message'] = mb_convert_encoding($log_insert['message'], 'UTF-8', 'UTF-8');
+						} else {
+							while (!empty($log_insert['message']) && !preg_match('//u', $log_insert['message'])) {
+								$log_insert['message'] = substr($log_insert['message'], 0, strlen($log_insert['message']) - 1);
+							}
+						}
+					}
 				}
 
 				// If we caused an error and the message we're trying to insert isn't the SQL error we'll skip the message

--- a/resources/class_debug.php
+++ b/resources/class_debug.php
@@ -167,7 +167,7 @@ class Log {
 				// This looks ugly and it is, but otherwise we'll produce SQL errors...
 				if(strlen($log_insert['message']) > 65535)
 				{
-					$log_insert['message'] = substr($log_insert['message'], 0, 65531)."...";
+					$log_insert['message'] = substr($log_insert['message'], 0, 65531);
 
 					// check that the content is valid UTF-8 - we may have sliced part-way into a unicode codepoint
 					if (!preg_match('//u', $log_insert['message'])) {
@@ -179,6 +179,8 @@ class Log {
 							}
 						}
 					}
+
+					$log_insert['message'] .= "...";
 				}
 
 				// If we caused an error and the message we're trying to insert isn't the SQL error we'll skip the message


### PR DESCRIPTION
Fixed #264
Fixed #266
Fixed #268 
Fixed #269 - S3 based avatars are imported as URL type avatars. A custom SQL query is then needed to fix the links to remove the `s3://` protocol and change it to `http://some_s3_domain/`.

The debug logs code trims input which may contain UTF-8 code points, which can result in invalid UTF-8. This PR adds some logic to correct this case.