### PR TITLE
Added support for PDO & fixed PHP 8 errors

### DIFF
--- a/index.php
+++ b/index.php
@@ -126,7 +126,7 @@ if(substr($mybb->settings['uploadspath'], 0, 2) == "./" || substr($mybb->setting
 	$mybb->settings['uploadspath'] = MYBB_ROOT.$mybb->settings['uploadspath'];
 }
 
-require_once MYBB_ROOT."inc/class_xml.php";
+require_once MYBB_ROOT."inc/class_xmlparser.php";
 
 // Include the converter resources
 require_once MERGE_ROOT."resources/functions.php";
@@ -141,6 +141,9 @@ if(file_exists(MYBB_ROOT."inc/db_base.php")) // MyBB 1.8.4+
 {
 	require_once MYBB_ROOT."inc/db_base.php";
 }
+if($config['database']['type'] == "mysql_pdo") {
+	require_once MYBB_ROOT."inc/AbstractPdoDbDriver.php";
+}
 require_once MYBB_ROOT."inc/db_{$config['database']['type']}.php";
 switch($config['database']['type'])
 {
@@ -152,6 +155,9 @@ switch($config['database']['type'])
 		break;
 	case "mysqli":
 		$db = new DB_MySQLi;
+		break;
+	case "mysql_pdo":
+		$db = new MysqlPdoDbDriver;
 		break;
 	default:
 		$db = new DB_MySQL;
@@ -595,11 +601,11 @@ else if(!$import_session['requirements_check'] || ($mybb->input['first_page'] ==
 	$checks['version_check_status'] = '<span class="pass">'.$lang->requirementspage_uptodate.'</span>';
 
 	// Check for a new version of the Merge System!
-	require_once MYBB_ROOT."inc/class_xml.php";
+	require_once MYBB_ROOT."inc/class_xmlparser.php";
 	$contents = merge_fetch_remote_file("http://www.mybb.com/merge_version_check.php");
 	if($contents)
 	{
-		$parser = new XMLParser($contents);
+		$parser = new MyBBXMLParser($contents);
 		$tree = $parser->get_tree();
 
 		$latest_code = (int)$tree['mybb_merge']['version_code']['value'];

--- a/index.php
+++ b/index.php
@@ -126,8 +126,6 @@ if(substr($mybb->settings['uploadspath'], 0, 2) == "./" || substr($mybb->setting
 	$mybb->settings['uploadspath'] = MYBB_ROOT.$mybb->settings['uploadspath'];
 }
 
-require_once MYBB_ROOT."inc/class_xmlparser.php";
-
 // Include the converter resources
 require_once MERGE_ROOT."resources/functions.php";
 require_once MERGE_ROOT.'resources/output.php';
@@ -137,14 +135,11 @@ require_once MERGE_ROOT.'resources/class_converter.php';
 
 $mybb->config = $config;
 
-if(file_exists(MYBB_ROOT."inc/db_base.php")) // MyBB 1.8.4+
-{
-	require_once MYBB_ROOT."inc/db_base.php";
-}
-if($config['database']['type'] == "mysql_pdo") {
-	require_once MYBB_ROOT."inc/AbstractPdoDbDriver.php";
-}
+require_once MYBB_ROOT."inc/db_base.php";
+require_once MYBB_ROOT.'inc/AbstractPdoDbDriver.php';
+
 require_once MYBB_ROOT."inc/db_{$config['database']['type']}.php";
+
 switch($config['database']['type'])
 {
 	case "sqlite":
@@ -153,11 +148,14 @@ switch($config['database']['type'])
 	case "pgsql":
 		$db = new DB_PgSQL;
 		break;
+	case "pgsql_pdo":
+		$db = new PostgresPdoDbDriver();
+		break;
 	case "mysqli":
 		$db = new DB_MySQLi;
 		break;
 	case "mysql_pdo":
-		$db = new MysqlPdoDbDriver;
+		$db = new MysqlPdoDbDriver();
 		break;
 	default:
 		$db = new DB_MySQL;
@@ -601,11 +599,10 @@ else if(!$import_session['requirements_check'] || ($mybb->input['first_page'] ==
 	$checks['version_check_status'] = '<span class="pass">'.$lang->requirementspage_uptodate.'</span>';
 
 	// Check for a new version of the Merge System!
-	require_once MYBB_ROOT."inc/class_xmlparser.php";
 	$contents = merge_fetch_remote_file("http://www.mybb.com/merge_version_check.php");
-	if($contents)
+	if(!empty($contents))
 	{
-		$parser = new MyBBXMLParser($contents);
+		$parser = create_xml_parser($contents);
 		$tree = $parser->get_tree();
 
 		$latest_code = (int)$tree['mybb_merge']['version_code']['value'];

--- a/resources/class_converter.php
+++ b/resources/class_converter.php
@@ -26,7 +26,7 @@ abstract class Converter
 	var $debug;
 
 	/**
-	 * @var DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite
+	 * @var DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite|PostgresPdoDbDriver|MysqlPdoDbDriver
 	 */
 	var $old_db;
 
@@ -168,8 +168,14 @@ abstract class Converter
 			case "pgsql":
 				$this->old_db = new DB_PgSQL;
 				break;
+			case "pgsql_pdo":
+				$this->old_db = new PostgresPdoDbDriver();
+				break;
 			case "mysqli":
 				$this->old_db = new DB_MySQLi;
+				break;
+			case "mysql_pdo":
+				$this->old_db = new MysqlPdoDbDriver();
 				break;
 			default:
 				$this->old_db = new DB_MySQL;
@@ -211,8 +217,14 @@ abstract class Converter
 					case "pgsql":
 						$this->old_db = new DB_PgSQL;
 						break;
+					case "pgsql_pdo":
+						$this->old_db = new PostgresPdoDbDriver();
+						break;
 					case "mysqli":
 						$this->old_db = new DB_MySQLi;
+						break;
+					case "mysql_pdo":
+						$this->old_db = new MysqlPdoDbDriver();
 						break;
 					default:
 						$this->old_db = new DB_MySQL;

--- a/resources/class_converter.php
+++ b/resources/class_converter.php
@@ -336,8 +336,10 @@ abstract class Converter
 			{
 				$mybb->input['config'][$dbs]['tableprefix'] = $tableprefix;
 			}
-			// Handling mysqli seperatly as the array above doesn't make a difference between mysql and mysqli
+			// Handling mysqli, mysql_pdo and pgsql_pdo separately.
 			$mybb->input['config']["mysqli"]['tableprefix'] = $tableprefix;
+			$mybb->input['config']["mysql_pdo"]['tableprefix'] = $tableprefix;
+			$mybb->input['config']["pgsql_pdo"]['tableprefix'] = $tableprefix;
 
 			if($import_session['old_db_user'])
 			{

--- a/resources/class_converter_module.php
+++ b/resources/class_converter_module.php
@@ -26,7 +26,7 @@ abstract class Converter_Module
 	var $default_values = array();
 
 	/**
-	 * @var DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite
+	 * @var DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite|PostgresPdoDbDriver|MysqlPdoDbDriver
 	 */
 	var $old_db;
 

--- a/resources/class_debug.php
+++ b/resources/class_debug.php
@@ -226,6 +226,7 @@ class Log {
 					);");
 					break;
 				case "pgsql":
+				case "pgsql_pdo":
 					$db->write_query("CREATE TABLE ".TABLE_PREFIX."debuglogs (
 						dlid serial,
 						type int NOT NULL default '0',

--- a/resources/class_error.php
+++ b/resources/class_error.php
@@ -31,7 +31,7 @@ class debugErrorHandler extends errorHandler {
 	 * @param integer $line The error line
 	 * @return boolean True if parsing was a success, otherwise assume a error
 	 */
-	function error($type, $message, $file=null, $line=0)
+	function error($type, $message, $file=null, $line=0, $allow_output=false)
 	{
 		// Error reporting turned off (either globally or by @ before erroring statement)
 		if(error_reporting() == 0)
@@ -57,7 +57,7 @@ class debugErrorHandler extends errorHandler {
 			$this->debug->log->warning("\$type: {$type} \$message: {$message} \$file: {$file} \$line: {$line}");
 		}
 
-		return parent::error($type, $message, $file, $line);
+		return parent::error($type, $message, $file, $line, $allow_output);
 	}
 
 	/**

--- a/resources/class_error.php
+++ b/resources/class_error.php
@@ -31,7 +31,7 @@ class debugErrorHandler extends errorHandler {
 	 * @param integer $line The error line
 	 * @return boolean True if parsing was a success, otherwise assume a error
 	 */
-	function error($type, $message, $file=null, $line=0, $allow_output=false)
+	function error($type, $message, $file=null, $line=0, $allow_output=true)
 	{
 		// Error reporting turned off (either globally or by @ before erroring statement)
 		if(error_reporting() == 0)

--- a/resources/modules/forums.php
+++ b/resources/modules/forums.php
@@ -163,6 +163,7 @@ abstract class Converter_Module_Forums extends Converter_Module
 				{
 					case "sqlite":
 					case "pgsql":
+					case "pgsql_pdo":
 						$query_child = $db->simple_select("forums", "fid", "','||parentlist||',' LIKE '%,{$forum['fid']},%'");
 						break;
 					default:

--- a/resources/output.php
+++ b/resources/output.php
@@ -446,15 +446,33 @@ END;
 			);
 		}
 
-		if(class_exists('PDO') && in_array("sqlite", $board->supported_databases))
+		if(class_exists('PDO'))
 		{
 			$supported_dbs = PDO::getAvailableDrivers();
-			if(in_array('sqlite', $supported_dbs))
+			if(in_array('sqlite', $supported_dbs) && in_array("sqlite", $board->supported_databases))
 			{
 				$dboptions['sqlite'] = array(
 					'class' => 'DB_SQLite',
 					'title' => 'SQLite 3',
 					'short_title' => 'SQLite',
+				);
+			}
+
+			if(in_array('pgsql', $supported_dbs) && in_array("pgsql", $board->supported_databases))
+			{
+				$dboptions['pgsql_pdo'] = array(
+					'class' => 'PostgresPdoDbDriver',
+					'title' => 'PostgreSQL (PDO)',
+					'short_title' => 'PostgreSQL (PDO)',
+				);
+			}
+
+			if(in_array('mysql', $supported_dbs) && in_array("mysql", $board->supported_databases))
+			{
+				$dboptions['mysql_pdo'] = array(
+					'class' => 'MysqlPdoDbDriver',
+					'title' => 'MySQL (PDO)',
+					'short_title' => 'MySQL (PDO)',
 				);
 			}
 		}
@@ -510,7 +528,7 @@ END;
 				continue;
 			}
 
-			/** @var DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite $db */
+			/** @var DB_MySQL|DB_MySQLi|DB_PgSQL|DB_SQLite|PostgresPdoDbDriver|MysqlPdoDbDriver $db */
 			$db = new $dbtype['class'];
 			$encodings = $db->fetch_db_charsets();
 


### PR DESCRIPTION
There will still be a lot of warnings in PHP 8 but at least the merge system will be functional. The thing I worry about the most is the following line of code:
`function error($type, $message, $file=null, $line=0, $allow_output=false)`

I set the default to false because the merge system has so many warnings that it becomes unusable because it obscures the view, temporary fix until the merge system has been rewritten?